### PR TITLE
overwrite request header to let msw intercept the urql requst.

### DIFF
--- a/src/stories/graphql-client.js
+++ b/src/stories/graphql-client.js
@@ -3,4 +3,9 @@ import { createClient, fetchExchange } from "urql";
 export const graphqlClient = createClient({
   url: "http://localhost/graphql",
   exchanges: [fetchExchange],
+  fetchOptions: {
+    headers: {
+      accept: "*/*"
+    }
+  }
 });


### PR DESCRIPTION
# What I did

overwrite the request header of the urql client.

# How it works

1. run `npm run storybook`
2. navigate to the "header -> logged in" story and check the console - MSW is enabled and you can find the graphql call is being intercepted

![storybook, msw intercepts a graphql call](https://user-images.githubusercontent.com/11014018/232120362-17c06410-9cb9-4715-af1a-ecf48f5cbaee.png)
